### PR TITLE
16 and 18 user stories

### DIFF
--- a/app/controllers/invoice_items_controller.rb
+++ b/app/controllers/invoice_items_controller.rb
@@ -1,0 +1,10 @@
+class InvoiceItemsController < ApplicationController
+  def update
+    merchant = Merchant.find(params[:merchant_id])
+    invoice = merchant.invoices.find(params[:id])
+    invoice_item = InvoiceItem.find(params[:invoice_item_id]) 
+
+    invoice_item.update(status: params[:status])
+    redirect_to "/merchants/#{merchant.id}/invoices/#{invoice.id}"
+  end
+end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -8,5 +8,6 @@ class InvoicesController < ApplicationController
   def show
     @merchant = Merchant.find(params[:merchant_id])
     @invoice = Invoice.find(params[:id])
+    @items_on_invoice = @invoice.items
   end
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -19,7 +19,7 @@
     <%@invoice.invoice_items.each do |invoice_item|%>
     <td><%=invoice_item.item.name%></td>
     <td><%=invoice_item.quantity%></td>
-    <td>$<%=invoice_item.unit_price%></td>
+    <td>$<%=(invoice_item.unit_price.to_f/100)%></td>
     <td><%=invoice_item.status%></td>
   </tr>
     <%end%>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -19,8 +19,17 @@
     <%@invoice.invoice_items.each do |invoice_item|%>
     <td><%=invoice_item.item.name%></td>
     <td><%=invoice_item.quantity%></td>
-    <td>$<%=(invoice_item.unit_price.to_f/100)%></td>
-    <td><%=invoice_item.status%></td>
-  </tr>
+    <td><%=(number_to_currency(invoice_item.unit_price.to_f/100))%></td>
+    
+      <td>
+        <%= form_with url: "/merchants/#{@merchant.id}/invoices/#{@invoice.id}", method: :patch, local: true do |form|%>
+        <div id=<%=invoice_item.id%>>
+          <%= form.select :status, ['pending', 'packaged', 'shipped'], selected:invoice_item.status %>
+          <%= form.hidden_field :invoice_item_id, value: invoice_item.id%>
+          <%= form.submit "Update Item Status" %>
+          </div>
+        <%end%>
+      </td>
+    </tr>
     <%end%>
 </table>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -6,3 +6,21 @@
 <h3>Customer:</h3>
 <p><%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 </div>
+
+<h3>Items on this invoice:</h3>
+<table>
+  <tr>
+    <th>Item Name</th>
+    <th>Quantity</th>
+    <th>Unit Price</th>
+    <th>Status</th>
+  </tr>
+  <tr>
+    <%@invoice.invoice_items.each do |invoice_item|%>
+    <td><%=invoice_item.item.name%></td>
+    <td><%=invoice_item.quantity%></td>
+    <td>$<%=invoice_item.unit_price%></td>
+    <td><%=invoice_item.status%></td>
+  </tr>
+    <%end%>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,6 @@ Rails.application.routes.draw do
     resources :invoices, only: [:index, :show]
 	end
 
+  patch '/merchants/:merchant_id/invoices/:id', to: 'invoice_items#update'
+
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -44,7 +44,6 @@ describe 'As a merchant', type: :feature do
 
     it "I see all of my items on the invoice including: item name, quantity of item ordered, the price sold for, the invoice item status" do
       visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
-
       expect(page).to have_content("Items on this invoice")
       expect(page).to have_content("Item Name")
       expect(page).to have_content("Quantity")
@@ -60,6 +59,16 @@ describe 'As a merchant', type: :feature do
       expect(page).to have_content(@invoice_item2.quantity)
       expect(page).to have_content(@invoice_item2.unit_price)
       expect(page).to have_content(@invoice_item2.status)
+
+      expect(page).to have_content(item3.name)
+      expect(page).to have_content(@invoice_item3.quantity)
+      expect(page).to have_content(@invoice_item3.unit_price)
+      expect(page).to have_content(@invoice_item3.status)
+
+      expect(page).to have_content(item4.name)
+      expect(page).to have_content(@invoice_item4.quantity)
+      expect(page).to have_content(@invoice_item4.unit_price)
+      expect(page).to have_content(@invoice_item4.status)
 
       expect(page).to_not have_content(item5.name)
     end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -16,11 +16,11 @@ describe 'As a merchant', type: :feature do
   let!(:invoice2) {create(:invoice, created_at: Date.new(2019, 3, 9), customer: customer2)}
 
   before(:each) do
-    create(:invoice_item, invoice: invoice1, item: item1)
-    create(:invoice_item, invoice: invoice1, item: item2)
-    create(:invoice_item, invoice: invoice1, item: item3)
-    create(:invoice_item, invoice: invoice1, item: item4)
-    create(:invoice_item, invoice: invoice2, item: item5)
+    @invoice_item1 = create(:invoice_item, invoice: invoice1, item: item1)
+    @invoice_item2 = create(:invoice_item, invoice: invoice1, item: item2)
+    @invoice_item3 = create(:invoice_item, invoice: invoice1, item: item3)
+    @invoice_item4 = create(:invoice_item, invoice: invoice1, item: item4)
+    @invoice_item5 = create(:invoice_item, invoice: invoice2, item: item5)
   end
 
   describe "When I visit my merchant's invoice show page" do
@@ -40,6 +40,28 @@ describe 'As a merchant', type: :feature do
         expect(page).to have_content(customer1.first_name)
         expect(page).to have_content(customer1.last_name)
       end
+    end
+
+    it "I see all of my items on the invoice including: item name, quantity of item ordered, the price sold for, the invoice item status" do
+      visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
+
+      expect(page).to have_content("Items on this invoice")
+      expect(page).to have_content("Item Name")
+      expect(page).to have_content("Quantity")
+      expect(page).to have_content("Unit Price")
+      expect(page).to have_content("Status")
+
+      expect(page).to have_content(item1.name)
+      expect(page).to have_content(@invoice_item1.quantity)
+      expect(page).to have_content(@invoice_item1.unit_price)
+      expect(page).to have_content(@invoice_item1.status)
+
+      expect(page).to have_content(item2.name)
+      expect(page).to have_content(@invoice_item2.quantity)
+      expect(page).to have_content(@invoice_item2.unit_price)
+      expect(page).to have_content(@invoice_item2.status)
+
+      expect(page).to_not have_content(item5.name)
     end
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -52,25 +52,45 @@ describe 'As a merchant', type: :feature do
 
       expect(page).to have_content(item1.name)
       expect(page).to have_content(@invoice_item1.quantity)
-      expect(page).to have_content(@invoice_item1.unit_price)
+      expect(page).to have_content(@invoice_item1.unit_price.to_f/100)
       expect(page).to have_content(@invoice_item1.status)
 
       expect(page).to have_content(item2.name)
       expect(page).to have_content(@invoice_item2.quantity)
-      expect(page).to have_content(@invoice_item2.unit_price)
+      expect(page).to have_content(@invoice_item2.unit_price.to_f/100)
       expect(page).to have_content(@invoice_item2.status)
 
       expect(page).to have_content(item3.name)
       expect(page).to have_content(@invoice_item3.quantity)
-      expect(page).to have_content(@invoice_item3.unit_price)
+      expect(page).to have_content(@invoice_item3.unit_price.to_f/100)
       expect(page).to have_content(@invoice_item3.status)
 
       expect(page).to have_content(item4.name)
       expect(page).to have_content(@invoice_item4.quantity)
-      expect(page).to have_content(@invoice_item4.unit_price)
+      expect(page).to have_content(@invoice_item4.unit_price.to_f/100)
       expect(page).to have_content(@invoice_item4.status)
 
       expect(page).to_not have_content(item5.name)
+    end
+
+    describe "shows each invoice item status is a select field, the invoice item's current status is selected" do
+      it 'when click select field, then I can select a new status for the item, next to field is a button to update item status' do
+        visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
+        
+        expect(page).to have_content(@invoice_item1.status)
+        expect(page).to have_button("Update Item Status")
+
+        within "##{@invoice_item1.id}" do
+          expect(@invoice_item1.status).to eq("pending")
+
+          select "shipped", from: :status
+          click_button 'Update Item Status'
+          expect(page).to have_select(selected: "shipped")
+          expect(page).to_not have_select(selected: "pending")
+        end
+        
+        expect(current_path).to eq("/merchants/#{merchant1.id}/invoices/#{invoice1.id}")
+      end
     end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -217,7 +217,6 @@ RSpec.describe 'merchant items index page', type: :feature do
 
 			it 'has date with most sales shown next to the item' do
 				visit merchant_items_path(merchant1)
-				save_and_open_page
         
 				within "#top_5_most_popular_items" do
 					within "##{item3.id}_popular_item" do

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe 'merchant items index page', type: :feature do
 			it 'has date with most sales shown next to the item' do
 				visit merchant_items_path(merchant1)
 				save_and_open_page
+        
 				within "#top_5_most_popular_items" do
 					within "##{item3.id}_popular_item" do
 						expect(page).to have_content("Top day for #{item3.name} was 03/01/2012")


### PR DESCRIPTION
16. Merchant Invoice Show Page: Invoice Item Information
As a merchant
When I visit my merchant invoice show page
Then I see all of my items on the invoice including:
- Item name
- The quantity of the item ordered
- The price the Item sold for
- The Invoice Item status
And I do not see any information related to Items for other merchants

18. Merchant Invoice Show Page: Update Item Status
As a merchant
When I visit my merchant invoice show page
I see that each invoice item status is a select field
And I see that the invoice item's current status is selected
When I click this select field,
Then I can select a new status for the Item,
And next to the select field I see a button to "Update Item Status"
When I click this button
I am taken back to the merchant invoice show page
And I see that my Item's status has now been updated

*added invoice_items controller